### PR TITLE
removing nil params as nil will raise errors

### DIFF
--- a/lib/binance/api/request.rb
+++ b/lib/binance/api/request.rb
@@ -9,6 +9,7 @@ module Binance
         def send!(api_key_type: :none, headers: {}, method: :get, path: '/', params: {}, security_type: :none)
           raise Error.new(message: "invalid security type #{security_type}") unless security_types.include?(security_type)
           all_headers = default_headers(api_key_type: api_key_type, security_type: security_type)
+          params.delete_if { |k, v| v.nil? }
           params.merge!(signature: signed_request_signature(params: params)) \
             if [:trade, :user_data].include?(security_type)
           # send() is insecure so don't use it.


### PR DESCRIPTION

According to binance official API  [compressed aggregate trades](compressedaggregate-trades-list) has only symbol as a mandatory parameter.

Nevertheless it raises error cause the params are being passed as nil:
```ruby
Binance::Api.compressed_aggregate_trades!(symbol: :IOSTBTC)
Binance::Api::Error: (-1105) Parameter 'fromId' was was empty.
```
This is a small fix to remove nil values from parameters at Request class.

Hope it is ok ,


Regards

