### PR TITLE
Bumps activesupport dependency requirement

### DIFF
--- a/binance-ruby.gemspec
+++ b/binance-ruby.gemspec
@@ -35,8 +35,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", '~> 3.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'pry', '~> 0.11.3'
-  
-  spec.add_dependency 'activesupport', '~> 5.1'
+
+  spec.add_dependency 'activesupport', ['>=5.1.0', '<7.0.0']
   spec.add_dependency 'awrence', '~> 1.0'
   spec.add_dependency 'httparty', '~> 0.15'
 end


### PR DESCRIPTION
Projects using Rails 6 can't use this gem because the `~> 5.1` requirement.

I added this so Rails 5 and 6 are supported but let me know if you have a different preference