### PR TITLE
use generic api key set by variables if no specialized key is set

### DIFF
--- a/lib/binance/api/configuration.rb
+++ b/lib/binance/api/configuration.rb
@@ -10,7 +10,7 @@ module Binance
 
         def api_key(type: nil)
           raise Error.new(message: "invalid api_key type: #{type}.") unless type.nil? || api_key_types.include?(type)
-          instance_api_key(type: type) || ENV["BINANCE_#{type.to_s.humanize.upcase}_API_KEY"] || ENV["BINANCE_API_KEY"]
+          instance_api_key(type: type) || ENV["BINANCE_#{type.to_s.humanize.upcase}_API_KEY"] || instance_api_key || ENV["BINANCE_API_KEY"]
         end
 
         def tld


### PR DESCRIPTION
If I set only the generic API keys via instance variables according to the readme, I end up with an empty API key in the request. This PR fixes that.