### PR TITLE
Fixes ActiveSupport::XmlMini::IsolatedExecutionState

### DIFF
--- a/lib/binance-ruby.rb
+++ b/lib/binance-ruby.rb
@@ -1,4 +1,11 @@
+require 'active_support/version'
+
+if ActiveSupport::VERSION::MAJOR > 6
+    require "active_support/isolated_execution_state" 
+end 
+
 require "active_support/core_ext/string"
+
 require "awrence"
 require "httparty"
 require "faye/websocket"


### PR DESCRIPTION
### Background 
https://github.com/Jakenberg/binance-ruby/issues/30

### Rails issue 
https://github.com/rails/rails/issues/43851

### TODO 
- [X] Optional require `active_support/isolated_execution_state` for active support versions beyond 6
- [X] Test

### Closed Issues 
- closes #30  